### PR TITLE
Create-freshness-function-in-search-index

### DIFF
--- a/freddaid_search_setup/index.py
+++ b/freddaid_search_setup/index.py
@@ -331,7 +331,17 @@ def create_index_body(
                 "name": f"{index_name}-scoring-profile",
                 "functionAggregation": "sum",
                 "text": {"weights": {"content": 45, "keyPhrases": 45, "title": 5}},
-                "functions": [],
+                "functions": [
+                    {
+                        "fieldName": "date_last_modified",
+                        "interpolation": "linear",
+                        "type": "freshness",
+                        "boost": 5,
+                        "freshness": {
+                            "boostingDuration": "P30D",
+                        },
+                    },
+                ],
             }
         ],
         "corsOptions": {"allowedOrigins": ["*"], "maxAgeInSeconds": 60},


### PR DESCRIPTION
- Introduced a new scoring function for the index that boosts documents based on the `date_last_modified` field.
- Configured the function to use linear interpolation with a boosting duration of 30 days.