### PR TITLE
Add-default-semantic-config

### DIFF
--- a/freddaid_search_setup/index.py
+++ b/freddaid_search_setup/index.py
@@ -355,6 +355,7 @@ def create_index_body(
         "charFilters": [],
         "similarity": {"@odata.type": "#Microsoft.Azure.Search.BM25Similarity"},
         "semantic": {
+            "defaultConfiguration": "my-semantic-config",
             "configurations": [
                 {
                     "name": "my-semantic-config",


### PR DESCRIPTION
- Added "defaultConfiguration": "my-semantic-config" to the semantic section of the index body to specify the default semantic configuration for improved search capabilities.